### PR TITLE
Don't pass reinstall=True as argument doesnt exist

### DIFF
--- a/plugin.video.kpn/resources/lib/base/l7/plugin.py
+++ b/plugin.video.kpn/resources/lib/base/l7/plugin.py
@@ -72,7 +72,7 @@ def _home(**kwargs):
 @route('_ia_install')
 def _ia_install(**kwargs):
     _close()
-    inputstream.install_widevine(reinstall=True)
+    inputstream.install_widevine()
 
 def reboot():
     _close()


### PR DESCRIPTION
I wasn't able to install wildvine without removing this argument. Got an exception saying there wasn't a method with that argument.