### PR TITLE
fix(NLZiet): missende imports toegevoegd.

### DIFF
--- a/plugin.video.nlziet/resources/lib/util.py
+++ b/plugin.video.nlziet/resources/lib/util.py
@@ -1,5 +1,7 @@
 import _strptime
+import certifi
 import datetime, re, time, xbmc
+import requests
 
 from collections import OrderedDict
 from resources.lib.base.l1.constants import ADDON_ID, DEFAULT_USER_AGENT, PROVIDER_NAME


### PR DESCRIPTION
Fix voor de volgende stacktrace. 

```   
    Traceback (most recent call last):
        File "plugin.video.nlziet\resources\lib\base\l5\signals.py", line 32, in throwable
        yield
        File "plugin.video.nlziet\resources\lib\base\l6\router.py", line 85, in dispatch
        function(**params)
        File "plugin.video.nlziet\resources\lib\base\l7\plugin.py", line 30, in decorated_function
        item = f(*args, **kwargs)
        File "plugin.video.nlziet\resources\lib\base\l8\menu.py", line 32, in home
        check_first()
        File "plugin.video.nlziet\resources\lib\base\l8\menu.py", line 1810, in check_first
        plugin_check_first()
        File "plugin.video.nlziet\resources\lib\util.py", line 63, in plugin_check_first
        except requests.exceptions.SSLError as err:
    NameError: name 'requests' is not defined