### PR TITLE
[KPN iTV] new API URL

### DIFF
--- a/plugin.video.kpn/resources/lib/constants.py
+++ b/plugin.video.kpn/resources/lib/constants.py
@@ -5,7 +5,7 @@ CONST_BASE_DOMAIN_MOD = False
 CONST_BASE_IP = ''
 
 CONST_URLS = {
-    'api': 'https://api.tv.kpn.com/101/1.2.0/A/nld/pctv/kpn',
+    'api': 'https://api.tv.prod.itvavs.prod.aws.kpn.com/101/1.2.0/A/nld/pctv/kpn',
     'base': 'https://tv.kpn.com',
     'image': 'https://images.tv.kpn.com'
 }


### PR DESCRIPTION
Fix for KPN Interactieve TV, seems like the API uses a new URL. (Doesn't fix search, listing or EPG yet)